### PR TITLE
Normalize filenames to default Unicode Normalization Form (NFC) so th…

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ CaseSensitivePathsPlugin.prototype.getFilenamesInDir = function (dir) {
         if (this.options.debug) {
             console.log('[CaseSensitivePathsPlugin] Reading directory', dir);
         }
-        return fs.readdirSync(dir);
+        return fs.readdirSync(dir).map(function(f) { return f.normalize ? f.normalize('NFC') : f; });
     }
 };
 
@@ -105,6 +105,7 @@ CaseSensitivePathsPlugin.prototype.apply = function(compiler) {
 
             // Trim ? off, since some loaders add that to the resource they're attemping to load
             var pathName = data.resource.split('?')[0];
+            pathName =  pathName.normalize ? pathName.normalize('NFC') : pathName;
             var realName = _this.fileExistsWithCaseSync(pathName);
 
             if (realName) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "case-sensitive-paths-webpack-plugin",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Enforces module path case sensitivity in Webpack",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
…at all utf8-characters are compared correctly.

I had some Norwegian letters in my filenames (æ, ø, å) and I got warnings that the files didn't exist. This PR fixes this, if string.prototype.normalize exists (if not, it just does what it used to).