### PR TITLE
Don't crash when a directory is deleted

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,14 @@ CaseSensitivePathsPlugin.prototype.getFilenamesInDir = function (dir) {
         if (this.options.debug) {
             console.log('[CaseSensitivePathsPlugin] Reading directory', dir);
         }
-        return fs.readdirSync(dir).map(function(f) { return f.normalize ? f.normalize('NFC') : f; });
+        try {
+            return fs.readdirSync(dir).map(function(f) { return f.normalize ? f.normalize('NFC') : f; });
+        } catch (err) {
+            if (this.options.debug) {
+                console.log('[CaseSensitivePathsPlugin] Failed to read directory', dir, err);
+            }
+            return [];
+        }
     }
 };
 


### PR DESCRIPTION
Fixes #8.
Test plan:

```
npm i -g create-react-app
create-react-app whatever
cd whatever
npm start
```

Add a directory called `src/something/` and add a file called `index.js` there.
Then add `import from './something'` to `src/index.js`.

Then delete `src/something/`.
Save `src/index.js` to force a recompilation.

Before this change, I would get a crash in this plugin:

```
Error: ENOENT: no such file or directory, scandir '/Users/dan/p/redux/examples/async/src/store'
    at Error (native)
    at Object.fs.readdirSync (fs.js:856:18)
    at CaseSensitivePathsPlugin.getFilenamesInDir (/Users/dan/p/redux/examples/async/node_modules/react-scripts/node_modules/case-sensitive-paths-webpack-plugin/index.js:45:19)
```

After this change, it recompiles with a regular error:

```
Failed to compile.

Error in ./template/src/App.js
Module not found: Error: [CaseSensitivePathsPlugin] `/Users/dan/p/create-react-app/template/src/components/index.js` does not match the corresponding path on disk - File does not exist.
 @ ./template/src/App.js 19:0-23
```

The point is that it doesn’t crash the whole server now, so I can fix the error and keep running it.