### PR TITLE
Add `files` to `package.json`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "import",
     "require"
   ],
+  "files": ["index.js"],
   "author": "Michael Pratt",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Prevents `demo`, `test`, and `.gitignore` from being published to NPM.  Shaves about 12 KB off the package size, a little more than half.