### PR TITLE
Add support for webpack 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,17 @@ os:
   - linux
   - osx
 
+env:
+  - WEBPACK_VERSION=1
+  - WEBPACK_VERSION=2
+  - WEBPACK_VERSION=3
+  - WEBPACK_VERSION=4
+
+install:
+  - npm install
+  - npm rm webpack
+  - npm install webpack@$WEBPACK_VERSION || true
+
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+
 node_js:
   - "node"
   - "8"
@@ -14,6 +15,11 @@ env:
   - WEBPACK_VERSION=2
   - WEBPACK_VERSION=3
   - WEBPACK_VERSION=4
+
+matrix:
+  exclude:
+  - node_js: "4"
+    env: WEBPACK_VERSION=4
 
 install:
   - npm install

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "case-sensitive-paths-webpack-plugin",
   "version": "2.1.1",
   "description": "Enforces module path case sensitivity in Webpack",
-  "engines": { "node": ">4.0" },
+  "engines": {
+    "node": ">=4"
+  },
   "main": "index.js",
   "scripts": {
     "test": "mocha test/",
@@ -35,6 +37,6 @@
     "eslint-plugin-import": "^2.3.0",
     "fs-extra": "^2.1.2",
     "mocha": "^3.0.1",
-    "webpack": "^1.13.1"
+    "webpack": "^4.0.1"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -117,8 +117,12 @@ describe('CaseSensitivePathsPlugin', () => {
     compiler.watch({}, (err, stats) => {
       if (err) done(err);
       compilationCount += 1;
+      console.log(compilationCount);
       if (compilationCount === 1) {
         const error = stats.toJson().errors[0];
+
+        console.log(stats.hasErrors(), stats.hasWarnings(), stats.toJson());
+        console.dir(stats.toJson());
 
         assert(stats.hasErrors());
         assert(error.indexOf('Cannot resolve') !== -1 || error.indexOf('Can\'t resolve') !== -1);
@@ -126,6 +130,9 @@ describe('CaseSensitivePathsPlugin', () => {
 
         fs.writeFileSync(testFile, 'module.exports = 0;');
       } else if (compilationCount === 2) {
+        console.log(stats.hasErrors(), stats.hasWarnings());
+        console.dir(stats.toJson());
+
         assert(fs.existsSync(testFile), 'Test file should exist');
         assert(!stats.hasErrors(), `Should have no errors, but has: \n${stats.toJson().errors}`);
         assert(!stats.hasWarnings());

--- a/test/index.js
+++ b/test/index.js
@@ -114,15 +114,13 @@ describe('CaseSensitivePathsPlugin', () => {
     if (fs.existsSync(testFile)) fs.unlinkSync(testFile);
 
     let compilationCount = 0;
-    compiler.watch({}, (err, stats) => {
+    const watcher = compiler.watch({}, (err, stats) => {
       if (err) done(err);
+
       compilationCount += 1;
-      console.log(compilationCount);
+
       if (compilationCount === 1) {
         const error = stats.toJson().errors[0];
-
-        console.log(stats.hasErrors(), stats.hasWarnings(), stats.toJson());
-        console.dir(stats.toJson());
 
         assert(stats.hasErrors());
         assert(error.indexOf('Cannot resolve') !== -1 || error.indexOf('Can\'t resolve') !== -1);
@@ -130,14 +128,13 @@ describe('CaseSensitivePathsPlugin', () => {
 
         fs.writeFileSync(testFile, 'module.exports = 0;');
       } else if (compilationCount === 2) {
-        console.log(stats.hasErrors(), stats.hasWarnings());
-        console.dir(stats.toJson());
-
         assert(fs.existsSync(testFile), 'Test file should exist');
         assert(!stats.hasErrors(), `Should have no errors, but has: \n${stats.toJson().errors}`);
         assert(!stats.hasWarnings());
+
         fs.unlinkSync(testFile);
-        done();
+
+        watcher.close(done);
       } else {
         throw new Error('Should not reach this point!');
       }

--- a/test/index.js
+++ b/test/index.js
@@ -1,167 +1,177 @@
-"use strict";
+/* eslint-env mocha */
 
 const isPlatformCaseInsensitive = /^[win|darwin]/.test(process.platform);
 
-let assert = require("assert");
-let fs = require("fs-extra");
-let path = require("path");
-let exec = require('child_process').exec;
-let webpack = require("webpack");
+const assert = require('assert');
+const fs = require('fs-extra');
+const path = require('path');
+const webpack = require('webpack');
+const webpackPkg = require('webpack/package.json');
 
-let CaseSensitivePathsPlugin = require("../");
+const CaseSensitivePathsPlugin = require('../');
 
 function webpackCompilerAtDir(dir, otherOpts) {
-    let opts = Object.assign({
-        context: path.join(__dirname, "fixtures", dir),
-        entry: "./entry",
-        output: {
-            path: path.join(__dirname, "js"),
-            filename: "result.js",
-        },
-        plugins: [
-            new CaseSensitivePathsPlugin()
-        ]
-    }, otherOpts);
-    return webpack(opts);
+  const opts = Object.assign({
+    context: path.join(__dirname, 'fixtures', dir),
+    entry: './entry',
+    output: {
+      path: path.join(__dirname, 'js'),
+      filename: 'result.js',
+    },
+    plugins: [
+      new CaseSensitivePathsPlugin(),
+    ],
+  }, otherOpts);
+
+  if (webpackPkg.version[0] === '4') {
+    opts.mode = 'development';
+  }
+
+  return webpack(opts);
 }
 
-describe("CaseSensitivePathsPlugin", function() {
+describe('CaseSensitivePathsPlugin', () => {
+  // This test will fail on case sensitive platforms, that's the whole point of this module.
+  // To ensure the rest of the library still works, disable *only this test.*
+  if (isPlatformCaseInsensitive) {
+    it('should compile and warn on wrong filename case', (done) => {
+      const compiler = webpackCompilerAtDir('wrong-case');
 
-    // This test will fail on case sensitive platforms, that's the whole point of this module.
-    // To ensure the rest of the library still works, disable *only this test.*
-    if (isPlatformCaseInsensitive) {
-      it("should compile and warn on wrong filename case", function (done) {
-        let compiler = webpackCompilerAtDir('wrong-case');
+      compiler.run((err, stats) => {
+        if (err) done(err);
+        assert(stats.hasErrors());
+        assert.equal(stats.hasWarnings(), false);
+        const jsonStats = stats.toJson();
+        assert.equal(jsonStats.errors.length, 1);
 
-        compiler.run(function (err, stats) {
-          if (err) done(err);
-          assert(stats.hasErrors());
-          assert.equal(stats.hasWarnings(), false);
-          let jsonStats = stats.toJson();
-          assert.equal(jsonStats.errors.length, 1);
+        const error = jsonStats.errors[0];
+        // check that the plugin produces the correct output
+        assert(error.indexOf('[CaseSensitivePathsPlugin]') > -1);
+        assert(error.indexOf('ExistingTestFile.js') > -1); // wrong file require
+        assert(error.indexOf('existingTestFile.js') > -1); // actual file name
 
-          let error = jsonStats.errors[0];
-          // check that the plugin produces the correct output
-          assert(error.indexOf('[CaseSensitivePathsPlugin]') > -1);
-          assert(error.indexOf('ExistingTestFile.js') > -1); // wrong file require
-          assert(error.indexOf('existingTestFile.js') > -1); // actual file name
-
-          done();
-        });
+        done();
       });
-    }
+    });
+  }
 
-    // For future reference: This test is somewhat of a race condition, these values seem to work well.
-    // If this test fails, sometimes just re-running will make it succeed.
-    it("should handle the deletion of a folder", function(done) {
-        let compiler = webpackCompilerAtDir('deleting-folder', {cache: false, watch: true});
+  // For future reference: This test is somewhat of a race condition, these values seem to work well.
+  // If this test fails, sometimes just re-running will make it succeed.
+  it('should handle the deletion of a folder', (done) => {
+    const compiler = webpackCompilerAtDir('deleting-folder', { cache: false, watch: true });
 
-        // create folder and file to be deleted
-        let testFolder = path.join(__dirname, "fixtures", "deleting-folder", "test-folder");
-        let testFile = path.join(testFolder, "testfile.js");
-        if (!fs.existsSync(testFolder)) fs.mkdirSync(testFolder);
-        if (!fs.existsSync(testFile)) fs.writeFileSync(testFile, "module.exports = '';");
+    // create folder and file to be deleted
+    const testFolder = path.join(__dirname, 'fixtures', 'deleting-folder', 'test-folder');
+    const testFile = path.join(testFolder, 'testfile.js');
+    if (!fs.existsSync(testFolder)) fs.mkdirSync(testFolder);
+    if (!fs.existsSync(testFile)) fs.writeFileSync(testFile, "module.exports = '';");
 
-        let watchCount = 0;
-        let resolved = false;
-        let jsonStats;
-        let watcher = compiler.watch({poll: 500, aggregateTimeout: 500}, function(err, stats) {
+    let watchCount = 0;
+    let resolved = false;
+    let jsonStats;
+    const watcher = compiler.watch({ poll: 500, aggregateTimeout: 500 }, (err, stats) => {
+      // We already detected the change and marked ourselves done, don't continue.
+      // Short circuits some intermittent test errors where this would be called again after
+      // test completion.
+      if (resolved) {
+        return;
+      }
 
-            // We already detected the change and marked ourselves done, don't continue.
-            // Short circuits some intermittent test errors where this would be called again after
-            // test completion.
-            if (resolved) {
-                return;
-            }
+      if (err) done(err);
+      watchCount += 1;
 
-            if (err) done(err);
-            watchCount++;
+      if (watchCount === 1) {
+        // First run should not error.
+        assert(!stats.hasErrors());
+        assert(!stats.hasWarnings());
 
-            if (watchCount === 1) {
-                // First run should not error.
-                assert(!stats.hasErrors());
-                assert(!stats.hasWarnings());
+        setTimeout(() => {
+          // after initial compile delete test folder
+          fs.unlinkSync(testFile);
+          fs.rmdirSync(testFolder);
+        }, 500);
+      } else if (stats.hasErrors()) {
+        assert(!stats.hasWarnings());
 
-                setTimeout(function() {
-                    // after initial compile delete test folder
-                    fs.unlinkSync(testFile);
-                    fs.rmdirSync(testFolder);
-                }, 500);
+        jsonStats = stats.toJson();
+        assert.equal(jsonStats.errors.length, 1);
+
+        resolved = true;
+        watcher.close(done);
+      } else {
+        throw Error('Did not detect error when folder was deleted. Try rerunning the test.');
+      }
+    });
+  });
+
+  it('should handle the creation of a new file', (done) => {
+    const compiler = webpackCompilerAtDir('file-creation');
+
+    const testFile = path.join(__dirname, 'fixtures', 'file-creation', 'testfile.js');
+    if (fs.existsSync(testFile)) fs.unlinkSync(testFile);
+
+    let compilationCount = 0;
+    compiler.watch({}, (err, stats) => {
+      if (err) done(err);
+      compilationCount += 1;
+      if (compilationCount === 1) {
+        const error = stats.toJson().errors[0];
+
+        assert(stats.hasErrors());
+        assert(error.indexOf('Cannot resolve') !== -1 || error.indexOf('Can\'t resolve') !== -1);
+        assert(!stats.hasWarnings());
+
+        fs.writeFileSync(testFile, 'module.exports = 0;');
+      } else if (compilationCount === 2) {
+        assert(fs.existsSync(testFile), 'Test file should exist');
+        assert(!stats.hasErrors(), `Should have no errors, but has: \n${stats.toJson().errors}`);
+        assert(!stats.hasWarnings());
+        fs.unlinkSync(testFile);
+        done();
+      } else {
+        throw new Error('Should not reach this point!');
+      }
+    });
+  });
+
+  it('should work with alternate fileSystems', (done) => {
+    let called = false;
+
+    webpack({
+      context: path.join(__dirname, 'fixtures', 'wrong-case'),
+      target: 'node',
+      output: {
+        path: path.join(__dirname, 'js'),
+        filename: 'result.js',
+      },
+      entry: './entry',
+      plugins: [
+        new CaseSensitivePathsPlugin(),
+        {
+          apply(compiler) {
+            let readdir;
+
+            const onCompile = () => {
+              readdir = readdir || compiler.inputFileSystem.readdir;
+              // eslint-disable-next-line no-param-reassign
+              compiler.inputFileSystem.readdir = function (p, cb) {
+                called = true;
+                fs.readdir(p, cb);
+              };
+            };
+
+            if (compiler.hooks) {
+              compiler.hooks.compile.tap('test', onCompile);
             } else {
-                if(stats.hasErrors()) {
-                    assert(!stats.hasWarnings());
-
-                    jsonStats = stats.toJson();
-                    assert.equal(jsonStats.errors.length, 1);
-
-                    resolved = true;
-                    watcher.close(done);
-                } else {
-                    throw Error("Did not detect error when folder was deleted. Try rerunning the test.");
-                }
+              compiler.plugin('compile', onCompile);
             }
-        });
+          },
+        },
+      ],
+    }, (err) => {
+      if (err) done(err);
+      assert(called, 'should use compiler fs');
+      done();
     });
-
-    it("should handle the creation of a new file", function(done) {
-        let compiler = webpackCompilerAtDir("file-creation");
-
-        let testFile = path.join(__dirname, "fixtures", "file-creation", "testfile.js");
-        if (fs.existsSync(testFile)) fs.unlinkSync(testFile);
-
-        let compilationCount = 0;
-        compiler.watch({}, function(err, stats) {
-            if (err) done(err);
-            compilationCount++;
-
-            if (compilationCount === 1) {
-                assert(stats.hasErrors());
-                assert(stats.toJson().errors[0].indexOf('Cannot resolve') !== -1);
-                assert(!stats.hasWarnings());
-
-                fs.writeFileSync(testFile, "module.exports = 0;");
-            } else if (compilationCount === 2) {
-                assert(fs.existsSync(testFile), 'Test file should exist');
-                assert(!stats.hasErrors(), 'Should have no errors, but has: \n' + stats.toJson().errors);
-                assert(!stats.hasWarnings());
-                fs.unlinkSync(testFile);
-                done()
-            } else {
-                throw new Error('Should not reach this point!')
-            }
-        })
-    });
-
-    it("should work with alternate fileSystems", function(done) {
-        let called = false;
-
-        webpack({
-            context: path.join(__dirname, "fixtures", "wrong-case"),
-            target: "node",
-            output: {
-                path: path.join(__dirname, "js"),
-                filename: "result.js"
-            },
-            entry: "./entry",
-            plugins: [
-                new CaseSensitivePathsPlugin(),
-                {
-                    apply: function(compiler) {
-                        let readdir;
-                        compiler.plugin('compile', function() {
-                            readdir = readdir || compiler.inputFileSystem.readdir;
-                            compiler.inputFileSystem.readdir = function(p, cb) {
-                                called = true;
-                                fs.readdir(p, cb);
-                            }
-                        })
-                    }
-                }
-            ]
-        }, function(err, stats) {
-            if (err) done(err);
-            assert(called, 'should use compiler fs');
-            done();
-        });
-    });
+  });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,7 @@
 /* eslint-env mocha */
+/* eslint-disable strict */
+
+'use strict';
 
 const isPlatformCaseInsensitive = /^[win|darwin]/.test(process.platform);
 


### PR DESCRIPTION
This PR adds support for the new plugin API's in webpack 4, while preserving backwards compatible support for older versions. Additionally tests should be run on all major webpack versions now.

I apologize for the big diff, most changes were autofixed eslint errors. Let me know if you want to me to revert and only apply the necessary changes and preserve the eslint errors.