### PR TITLE
Fix use of NormalModuleFactory.afterResolve for webpack 5

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,8 +163,8 @@ CaseSensitivePathsPlugin.prototype.apply = function(compiler) {
       if (realName) {
         if (realName === '!nonexistent') {
           // If file does not exist, let Webpack show a more appropriate error.
-          if (data.createData) done(null);
-          else done(null, data);
+          if (data.createData) done(null, false);
+          else done();
         } else {
           done(
             new Error(
@@ -173,9 +173,9 @@ CaseSensitivePathsPlugin.prototype.apply = function(compiler) {
           );
         }
       } else if (data.createData) {
-        done(null);
+        done(null, false);
       } else {
-        done(null, data);
+        done();
       }
     });
   };


### PR DESCRIPTION
Assuming @tim-soft (OP for #56) was having the same issue as @lucasecdb, this change should be enough to add Webpack 5 support (& close #56).

As per the error message shown in @lucasecdb's screenshot, the `NormalModuleFactory.afterResolve` has been changed to a bailing hook, instead of a waterfall hook. So I've updated `checkFile` as a part of this change to reflect that 👍